### PR TITLE
Implemented new callbacks from in elixir 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: elixir
 elixir:
-  - 1.5.1
+  - 1.6
   - 1.7
-  - 1.8.1
+  - 1.8
 otp_release:
   - 21.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: elixir
 elixir:
   - 1.5.1
+  - 1.7
+  - 1.8.1
 otp_release:
-  - 20.0
+  - 21.2

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ def deps do
 end
 ```
 
-## Usage (Elixir >= 1.5)
+## Usage
 
 After installing jalaali package. you can create Dates/DateTimes in jalaali or convert
 Dates/DateTimes form other calendars back an forth.
@@ -55,37 +55,6 @@ just copy those modules but its just better to migrate to 1.5 or above**
 ```
 
   Thats super easy. :)
-
-## Usage (Elixir < 1.5) [Old bad way]
-__&ast;IMPORTANT&ast; Do not use these methods if you can migrate to Elixir 1.5 or above__
-
-After installing jalaali package. you can use it for:
-
-  - Converting Gregorian dates to Jalaali:
-
-```elixir
-  jal_date = Jalaali.to_jalaali(~D[2015-02-29])
-```
-
-  - Converting Jalaali dates to Gregorian:
-
-```elixir
-  gre_date = Jalaali.to_gregorian(~D[1395-03-15])
-```
-
-  - Checking for Jalaali leap years:
-
-```elixir
-  Jalaali.is_leap_jalaali_year(1395)
-  true
-```
-
-  - Get a Jalaali month lenght
-
-```elixir
-  Jalaali.jalaali_month_length(1395, 12)
-  30
-```
 
 ## License
 

--- a/lib/jalaali/calendar.ex
+++ b/lib/jalaali/calendar.ex
@@ -246,7 +246,6 @@ defmodule Jalaali.Calendar do
       iex> Jalaali.Calendar.year_of_era(-1)
       {2, 0}
   """
-  @doc since: "0.3.0"
   @spec year_of_era(year) :: {year, era :: 0..1}
   @impl true
   def year_of_era(year) when is_integer(year) and year > 0, do: {year, 1}
@@ -264,7 +263,6 @@ defmodule Jalaali.Calendar do
       12
 
   """
-  @doc since: "0.3.0"
   @spec months_in_year(year) :: 12
   @impl true
   def months_in_year(_year), do: @months_in_year
@@ -282,7 +280,6 @@ defmodule Jalaali.Calendar do
       iex> Jalaali.Calendar.quarter_of_year(2678, 12, 28)
       4
   """
-  @doc since: "0.3.0"
   @spec quarter_of_year(year, month, day) :: 1..4
   @impl true
   def quarter_of_year(year, month, day)
@@ -304,7 +301,6 @@ defmodule Jalaali.Calendar do
       iex> Jalaali.Calendar.day_of_era(-1, 12, 29)
       {367, 0}
   """
-  @doc since: "0.3.0"
   @spec day_of_era(year, month, day) :: {day :: pos_integer(), era :: 0..1}
   @impl true
   def day_of_era(year, month, day)
@@ -333,7 +329,6 @@ defmodule Jalaali.Calendar do
       59
 
   """
-  @doc since: "0.3.0"
   @spec day_of_year(year, month, day) :: 1..366
   @impl true
   def day_of_year(year, month, day)

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule Jalaali.Mixfile do
       deps: deps(),
       docs: [
         source_ref: "v#{@version}",
-        main: "README",
+        main: "readme",
         canonical: "http://hexdocs.pm/jalaali",
         source_url: "https://github.com/jalaali/elixir-jalaali",
         extras: ["README.md"]

--- a/mix.exs
+++ b/mix.exs
@@ -1,21 +1,25 @@
 defmodule Jalaali.Mixfile do
   use Mix.Project
 
-  @version "0.2.1"
+  @version "0.3.0"
 
   def project do
-    [app: :jalaali,
-     version: @version,
-     elixir: "~> 1.3",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     description: description(),
-     package: package(),
-     deps: deps(),
-     docs: [source_ref: "v#{@version}", main: "README",
-            canonical: "http://hexdocs.pm/jalaali",
-            source_url: "https://github.com/jalaali/elixir-jalaali",
-            extras: ["README.md"]]
+    [
+      app: :jalaali,
+      version: @version,
+      elixir: "~> 1.3",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      description: description(),
+      package: package(),
+      deps: deps(),
+      docs: [
+        source_ref: "v#{@version}",
+        main: "README",
+        canonical: "http://hexdocs.pm/jalaali",
+        source_url: "https://github.com/jalaali/elixir-jalaali",
+        extras: ["README.md"]
+      ]
     ]
   end
 
@@ -37,8 +41,7 @@ defmodule Jalaali.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:ex_doc, "~> 0.14", only: :dev},
-      {:earmark, "~> 1.0", only: :dev}
+      {:ex_doc, "~> 0.20.1", only: :dev}
     ]
   end
 
@@ -50,11 +53,11 @@ defmodule Jalaali.Mixfile do
 
   defp package do
     [
-     name: :jalaali,
-     files: ["lib", "mix.exs", "README*", "LICENSE"],
-     maintainers: ["Alisina Bahadori"],
-     licenses: ["MIT"],
-     links: %{"GitHub" => "https://github.com/jalaali/elixir-jalaali"}
+      name: :jalaali,
+      files: ["lib", "mix.exs", "README*", "LICENSE"],
+      maintainers: ["Alisina Bahadori"],
+      licenses: ["MIT"],
+      links: %{"GitHub" => "https://github.com/jalaali/elixir-jalaali"}
     ]
   end
 end


### PR DESCRIPTION
Fix #8 

## Changes

 - Add `day_of_era/3`.
 - Add `day_of_year/3`.
 - Add `months_in_year/1`.
 - Add `quarter_of_year/3`.
 - Add `year_of_era/1`.
 - Added tests for all above implementations.
 - Bump `ex_doc` version to `0.20.1`.
 - Remove `README.md` section for elixir<1.5.
 - Bump version to `0.3.0`
 - Changed travis-ci elixir versions.